### PR TITLE
Display navigation items inline-block.

### DIFF
--- a/static/css/style.less
+++ b/static/css/style.less
@@ -295,7 +295,7 @@ img {
     li {
         font-family: Eagle, Helvetica, sans-serif;
         font-size: 1.5em;
-        display: inline;
+        display: inline-block;
         margin: 0 0.5em;
         @media (max-width: @small) {
             font-size: 1em;


### PR DESCRIPTION
Since items in the navigation list were being displayed `inline`, the lists were not being displayed properly on smaller screens. This fixes #4. 
